### PR TITLE
Update to 1.21(.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.1-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.matthewprenger.cursegradle' version '1.4.0'
 	id 'com.modrinth.minotaur' version '2.7.5'
@@ -7,7 +7,7 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = "${project.mod_version}+mc.${project.minecraft_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@ org.gradle.jvmargs       = -Xmx1G
 
 #Fabric properties
 minecraft_major_version  = 1.20
-minecraft_version        = 1.20.4
+minecraft_version        = 1.21.1
 yarn_mappings            = 3
-loader_version           = 0.15.2
+loader_version           = 0.16.5
 
 #Mod properties
-mod_version              = 1.3.11
+mod_version              = 1.3.12
 mod_release              = release
-mod_mc_version_specifier = 1.20.3+
-mod_mc_versions          = 1.20.3;1.20.4
-curseforge_mc_versions   = 1.20.3;1.20.4
+mod_mc_version_specifier = 1.21.x
+mod_mc_versions          = 1.21;1.21.1
+curseforge_mc_versions   = 1.21;1.21.1
 maven_group              = de.siphalor
 archives_base_name       = amecs
 
 #Dependencies
-fabric_api_version       = 0.91.2+1.20.4
+fabric_api_version       = 0.104.0+1.21.1
 amecs_api_version        = 1.5.5+mc1.20.2
 nmuk_version             = 1.1.0+mc1.20.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Thu Sep 12 08:10:22 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
-networkTimeout=10000
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/siphalor/amecs/Amecs.java
+++ b/src/main/java/de/siphalor/amecs/Amecs.java
@@ -12,12 +12,11 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.gui.screen.option.ControlsListWidget;
 import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerModelPart;
 import net.minecraft.text.Text;
 import net.minecraft.text.TextColor;
-import net.minecraft.text.TranslatableTextContent;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import org.apache.commons.lang3.StringUtils;
@@ -45,14 +44,14 @@ public class Amecs implements ClientModInitializer {
 
     private static final String SKIN_LAYER_CATEGORY = MOD_ID + ".key.categories.skin_layers";
 
-	public static final KeyBinding ESCAPE_KEYBINDING = KeyBindingHelper.registerKeyBinding(new AmecsKeyBinding(new Identifier(MOD_ID, "alternative_escape"), InputUtil.Type.KEYSYM, -1, "key.categories.ui", new KeyModifiers()));
+	public static final KeyBinding ESCAPE_KEYBINDING = KeyBindingHelper.registerKeyBinding(new AmecsKeyBinding(Identifier.of(MOD_ID, "alternative_escape"), InputUtil.Type.KEYSYM, -1, "key.categories.ui", new KeyModifiers()));
 
     @Override
     public void onInitializeClient() {
-        KeyBindingHelper.registerKeyBinding(new ToggleAutoJumpKeyBinding(new Identifier(MOD_ID, "toggle_auto_jump"), InputUtil.Type.KEYSYM, 66, "key.categories.movement", new KeyModifiers()));
+        KeyBindingHelper.registerKeyBinding(new ToggleAutoJumpKeyBinding(Identifier.of(MOD_ID, "toggle_auto_jump"), InputUtil.Type.KEYSYM, 66, "key.categories.movement", new KeyModifiers()));
 
         Arrays.stream(PlayerModelPart.values())
-                .map(playerModelPart -> new SkinLayerKeyBinding(new Identifier(MOD_ID, "toggle_" + playerModelPart.getName().toLowerCase(Locale.ENGLISH)), InputUtil.Type.KEYSYM, -1, SKIN_LAYER_CATEGORY, playerModelPart))
+                .map(playerModelPart -> new SkinLayerKeyBinding(Identifier.of(MOD_ID, "toggle_" + playerModelPart.getName().toLowerCase(Locale.ENGLISH)), InputUtil.Type.KEYSYM, -1, SKIN_LAYER_CATEGORY, playerModelPart))
                 .forEach(KeyBindingHelper::registerKeyBinding);
     }
 

--- a/src/main/java/de/siphalor/amecs/keybinding/SkinLayerKeyBinding.java
+++ b/src/main/java/de/siphalor/amecs/keybinding/SkinLayerKeyBinding.java
@@ -4,8 +4,8 @@ import de.siphalor.amecs.Amecs;
 import de.siphalor.amecs.api.AmecsKeyBinding;
 import de.siphalor.amecs.api.KeyModifiers;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.util.InputUtil;
+import net.minecraft.entity.player.PlayerModelPart;
 import net.minecraft.util.Identifier;
 
 public class SkinLayerKeyBinding extends AmecsKeyBinding {


### PR DESCRIPTION
fixes `new Identifier` not correct anymore must use `Identifier.of` and name change for import `PlayerModelParts`

fixes: #87 