### PR TITLE
Fix key descriptions not showing up on 26.2

### DIFF
--- a/amecs-key-mapping-descriptions/src/main/java/de/siphalor/amecs/key_mapping_descriptions/impl/mixin/MixinKeyBindingEntry.java
+++ b/amecs-key-mapping-descriptions/src/main/java/de/siphalor/amecs/key_mapping_descriptions/impl/mixin/MixinKeyBindingEntry.java
@@ -97,7 +97,7 @@ public abstract class MixinKeyBindingEntry
 		String descriptionKey = key.getName() + OLD_DESCRIPTION_SUFFIX;
 		//# if MC_VERSION_NUMBER >= 260200
 		Language language = Language.getInstance();
-		if (language.has(descriptionKey)) {
+		if (!language.has(descriptionKey)) {
 			descriptionKey = key.getName() + DESCRIPTION_SUFFIX;
 		}
 		if (!language.has(descriptionKey)) {


### PR DESCRIPTION
A `!` was forgotten in the 26.2 branch.