### PR TITLE
Preserve key mappings with equal sort order in the Controls search

### DIFF
--- a/amecs-bundle/src/main/java/de/siphalor/amecs/gui/SearchFieldControlsListWidget.java
+++ b/amecs-bundle/src/main/java/de/siphalor/amecs/gui/SearchFieldControlsListWidget.java
@@ -66,11 +66,11 @@ public class SearchFieldControlsListWidget
 
 	private int lastChildrenCount = 0;
 	//# if MC_VERSION_NUMBER >= 11802
-	private final Set<KeyBindsList.KeyEntry> allKeyEntries =
+	private final List<KeyBindsList.KeyEntry> allKeyEntries =
 	//# else
-	//- private final Set<ControlList.KeyEntry> allKeyEntries =
+	//- private final List<ControlList.KeyEntry> allKeyEntries =
 	//# end
-			new TreeSet<>(Comparator.comparing(o -> ((IKeyBindingEntry) o).amecs$getKeyBinding()));
+			new ArrayList<>();
 
 	public SearchFieldControlsListWidget(
 			//# if MC_VERSION_NUMBER >= 11802
@@ -174,6 +174,8 @@ public class SearchFieldControlsListWidget
 					Amecs.log(Level.ERROR, "An unexpected exception occurred during recompilation of controls list!", e);
 				}
 			}
+
+			allKeyEntries.sort(Comparator.comparing(o -> ((IKeyBindingEntry) o).amecs$getKeyBinding()));
 
 			children.clear();
 

--- a/gradle/mc-26.2.0/gradle.properties
+++ b/gradle/mc-26.2.0/gradle.properties
@@ -1,6 +1,6 @@
 minecraft.version.major = 26.2
 minecraft.version.title = 26.2
-minecraft.version.supported = 26.2-pre-2
+minecraft.version.supported = 26.2
 
 fabric.loom = plain
 

--- a/gradle/mc-26.2.0/mc.versions.toml
+++ b/gradle/mc-26.2.0/mc.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-fabric-api = "0.150.1+26.2"
+fabric-api = "0.158.0+26.2"
 java = "21"
-minecraft = "26.2-pre-2"
+minecraft = "26.2"
 
 [libraries]
 #controlling = { group = "com.blamejared.controlling", name = "Controlling-fabric-1.21.9", version = "27.0.2" }


### PR DESCRIPTION
## What does this change do?

Preserves all key entries in the Controls search list while retaining the existing sort order.

## Why is this needed?

`KeyMapping.compareTo()` is an ordering comparator, not an identity check. When distinct mappings have the same sort order, `TreeSet` treats them as duplicates and silently removes one. This can cause keybinds or categories to disappear from the Controls screen. ex [Gamma Ultis](https://modrinth.com/mod/gamma-utils)

The implementation now stores entries in a list and sorts them explicitly. Both the current and legacy preprocessor branches use a `List`, so comparator equality no longer removes mappings and older generated variants remain compilable.


Also updated the 26.2 build metadata from the pre-release version to stable Minecraft 26.2 and Fabric API `0.158.0+26.2`.


Related to #115. This PR changes the Amecs Controls search path, while #115 describes the separate NMUK loading path.